### PR TITLE
#card-29304644 Fix create-user endpoint name

### DIFF
--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -14,7 +14,7 @@ const {
 const { ADMIN } = roles;
 
 const authRoute = (router) => {
-  router.route('/auth/signup')
+  router.route('/auth/create-user')
   /**
      * @swagger
      * components:
@@ -41,7 +41,7 @@ const authRoute = (router) => {
 
   /**
      * @swagger
-     * /api/v1/auth/signup:
+     * /api/v1/auth/create-user:
      *   post:
      *     tags:
      *       - Auth

--- a/src/test/routes/auth.spec.js
+++ b/src/test/routes/auth.spec.js
@@ -67,8 +67,8 @@ describe('AUTH', () => {
         });
     });
   });
-  describe('POST /auth/signup', () => {
-    const signupEndpoint = `${BACKEND_BASE_URL}/auth/signup`;
+  describe('POST /auth/create-user', () => {
+    const signupEndpoint = `${BACKEND_BASE_URL}/auth/create-user`;
     let adminToken, userToken;
     before(async () => {
       adminToken = generateToken({ id: 1, roleId: 1 });


### PR DESCRIPTION
#### What does this PR do?
This PR changes signup endpoint name to create-user
#### Description of Task to be completed?
- fix create-user endpoint name from signup
- test endpoint
#### How should this be manually tested?
- clone repo
- install dependencies using npm install
- create .env in root dir and add server port variable
- npm run start:dev
- using postman POST localhost:4000/api/v1/auth/create-user
#### What are the relevant Project Card Link?
[#card-29304644](https://github.com/dinorhythms/Teamwork-Backend/projects/1#card-29304644)
